### PR TITLE
Add functions for getting interface names and paths

### DIFF
--- a/rosidl_runtime_py/__init__.py
+++ b/rosidl_runtime_py/__init__.py
@@ -16,11 +16,23 @@ from .convert import get_message_slot_types
 from .convert import message_to_csv
 from .convert import message_to_ordereddict
 from .convert import message_to_yaml
+from .get_interfaces import get_action_interfaces
+from .get_interfaces import get_interface_packages
+from .get_interfaces import get_interface_path
+from .get_interfaces import get_interfaces
+from .get_interfaces import get_message_interfaces
+from .get_interfaces import get_service_interfaces
 from .import_message import import_message_from_namespaced_type
 from .set_message import set_message_fields
 
 
 __all__ = [
+    'get_action_interfaces',
+    'get_interface_packages',
+    'get_message_interfaces',
+    'get_service_interfaces',
+    'get_interface_path',
+    'get_interfaces',
     'get_message_slot_types',
     'import_message_from_namespaced_type',
     'message_to_csv',

--- a/rosidl_runtime_py/get_interfaces.py
+++ b/rosidl_runtime_py/get_interfaces.py
@@ -38,7 +38,7 @@ def _get_interfaces(package_names: Iterable[str] = []) -> Dict[str, List[str]]:
         try:
             content, _ = get_resource('rosidl_interfaces', package_name)
         except LookupError:
-            pass
+            continue
         interfaces[package_name] = content.splitlines()
     return interfaces
 

--- a/rosidl_runtime_py/get_interfaces.py
+++ b/rosidl_runtime_py/get_interfaces.py
@@ -1,0 +1,134 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from ament_index_python import get_resource
+from ament_index_python import get_resources
+from ament_index_python import has_resource
+
+
+def get_all_interface_packages():
+    return get_resources('rosidl_interfaces')
+
+
+def get_interfaces(package_name):
+    if not has_resource('packages', package_name):
+        raise LookupError('Unknown package {}'.format(package_name))
+    try:
+        content, _ = get_resource('rosidl_interfaces', package_name)
+    except LookupError:
+        return []
+    interface_names = content.splitlines()
+    return list(sorted({
+        n.rsplit('.', 1)[0]
+        for n in interface_names
+        if '_' not in n}))
+
+
+def get_interface_path(parts):
+    prefix_path = has_resource('packages', parts[0])
+    joined = '/'.join(parts)
+    if len(parts[-1].rsplit('.', 1)) == 1:
+        joined += '.idl'
+    interface_path = os.path.join(
+        prefix_path, 'share', joined)
+    if not os.path.exists(interface_path):
+        raise LookupError('Could not find the interface {!r}'.format(interface_path))
+    return interface_path
+
+
+def get_all_action_types():
+    all_action_types = {}
+    for package_name in get_resources('rosidl_interfaces'):
+        action_types = get_action_types(package_name)
+        if action_types:
+            all_action_types[package_name] = action_types
+    return all_action_types
+
+
+def get_action_types(package_name):
+    if not has_resource('packages', package_name):
+        raise LookupError('Unknown package name')
+    try:
+        content, _ = get_resource('rosidl_interfaces', package_name)
+    except LookupError:
+        return []
+    interface_names = content.splitlines()
+    # TODO(jacobperron) this logic should come from a rosidl related package
+    # Only return actions in action folder
+    return list(sorted({
+        n[7:].rsplit('.', 1)[0]
+        for n in interface_names
+        if n.startswith('action/') and (n[-4:] == '.idl' or n[-7:] == '.action')}))
+
+
+def get_all_message_types():
+    all_message_types = {}
+    for package_name in get_resources('rosidl_interfaces'):
+        message_types = get_message_types(package_name)
+        if message_types:
+            all_message_types[package_name] = message_types
+    return all_message_types
+
+
+def get_message_types(package_name):
+    if not has_resource('packages', package_name):
+        raise LookupError('Unknown package name')
+    try:
+        content, _ = get_resource('rosidl_interfaces', package_name)
+    except LookupError:
+        return []
+    interface_names = content.splitlines()
+    # TODO(dirk-thomas) this logic should come from a rosidl related package
+    # Only return messages in msg folder
+    return list(sorted({
+        n[4:-4]
+        for n in interface_names
+        if n.startswith('msg/') and n[-4:] in ('.idl', '.msg')}))
+
+
+def get_all_service_types():
+    all_service_types = {}
+    for package_name in get_resources('rosidl_interfaces'):
+        service_types = get_service_types(package_name)
+        if service_types:
+            all_service_types[package_name] = service_types
+    return all_service_types
+
+
+def get_service_types(package_name):
+    if not has_resource('packages', package_name):
+        raise LookupError('Unknown package name')
+    try:
+        content, _ = get_resource('rosidl_interfaces', package_name)
+    except LookupError:
+        return []
+    interface_names = content.splitlines()
+    # TODO(dirk-thomas) this logic should come from a rosidl related package
+    # Only return services in srv folder
+    return list(sorted({
+        n[4:-4]
+        for n in interface_names
+        if n.startswith('srv/') and n[-4:] in ('.idl', '.srv')}))
+
+
+def get_message_path(package_name, message_name):
+    message_types = get_message_types(package_name)
+    if message_name not in message_types:
+        raise LookupError('Unknown message name')
+    prefix_path = has_resource('packages', package_name)
+    # TODO(dirk-thomas) this logic should come from a rosidl related package
+    return os.path.join(
+        prefix_path, 'share', package_name, 'msg', message_name + '.msg')

--- a/test/rosidl_runtime_py/test_get_interfaces.py
+++ b/test/rosidl_runtime_py/test_get_interfaces.py
@@ -1,0 +1,180 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import pytest
+
+from rosidl_runtime_py import get_action_interfaces
+from rosidl_runtime_py import get_interface_packages
+from rosidl_runtime_py import get_interface_path
+from rosidl_runtime_py import get_interfaces
+from rosidl_runtime_py import get_message_interfaces
+from rosidl_runtime_py import get_service_interfaces
+
+# these packages are listed as dependencies in the package.xml
+INTERFACE_PACKAGE = 'test_msgs'
+NON_INTERFACE_PACKAGE = 'rosidl_parser'
+
+
+def test_get_interface_packages():
+    packages = get_interface_packages()
+    assert len(packages) > 0
+    assert INTERFACE_PACKAGE in packages
+    assert NON_INTERFACE_PACKAGE not in packages
+
+
+def test_get_interfaces():
+    # no input
+    interfaces = get_interfaces()
+    assert len(interfaces) > 0
+    assert INTERFACE_PACKAGE in interfaces
+    assert NON_INTERFACE_PACKAGE not in interfaces
+    assert len(interfaces[INTERFACE_PACKAGE]) > 0
+
+    # one package
+    interfaces = get_interfaces([INTERFACE_PACKAGE])
+    assert len(interfaces) > 0
+    assert INTERFACE_PACKAGE in interfaces
+    assert NON_INTERFACE_PACKAGE not in interfaces
+    assert len(interfaces[INTERFACE_PACKAGE]) > 0
+
+    # multiple packages
+    interfaces = get_interfaces([INTERFACE_PACKAGE, NON_INTERFACE_PACKAGE])
+    assert len(interfaces) > 0
+    assert INTERFACE_PACKAGE in interfaces
+    assert NON_INTERFACE_PACKAGE not in interfaces
+    assert len(interfaces[INTERFACE_PACKAGE]) > 0
+
+    # unknown package name
+    with pytest.raises(LookupError):
+        get_interfaces(['test_not_package_name_you_are_bad_to_use_this_name'])
+
+
+def test_get_message_interfaces():
+    # no input
+    interfaces = get_message_interfaces()
+    assert len(interfaces) > 0
+    assert INTERFACE_PACKAGE in interfaces
+    assert NON_INTERFACE_PACKAGE not in interfaces
+    assert len(interfaces[INTERFACE_PACKAGE]) > 0
+
+    # one package
+    interfaces = get_message_interfaces([INTERFACE_PACKAGE])
+    assert len(interfaces) > 0
+    assert INTERFACE_PACKAGE in interfaces
+    assert NON_INTERFACE_PACKAGE not in interfaces
+    assert len(interfaces[INTERFACE_PACKAGE]) > 0
+
+    # multiple packages
+    interfaces = get_message_interfaces([INTERFACE_PACKAGE, NON_INTERFACE_PACKAGE])
+    assert len(interfaces) > 0
+    assert INTERFACE_PACKAGE in interfaces
+    assert NON_INTERFACE_PACKAGE not in interfaces
+    assert len(interfaces[INTERFACE_PACKAGE]) > 0
+
+    # unknown package name
+    with pytest.raises(LookupError):
+        get_message_interfaces(['test_not_package_name_you_are_bad_to_use_this_name'])
+
+
+def test_get_service_interfaces():
+    # no input
+    interfaces = get_service_interfaces()
+    assert len(interfaces) > 0
+    assert INTERFACE_PACKAGE in interfaces
+    assert NON_INTERFACE_PACKAGE not in interfaces
+    assert len(interfaces[INTERFACE_PACKAGE]) > 0
+
+    # one package
+    interfaces = get_service_interfaces([INTERFACE_PACKAGE])
+    assert len(interfaces) > 0
+    assert INTERFACE_PACKAGE in interfaces
+    assert NON_INTERFACE_PACKAGE not in interfaces
+    assert len(interfaces[INTERFACE_PACKAGE]) > 0
+
+    # multiple packages
+    interfaces = get_service_interfaces([INTERFACE_PACKAGE, NON_INTERFACE_PACKAGE])
+    assert len(interfaces) > 0
+    assert INTERFACE_PACKAGE in interfaces
+    assert NON_INTERFACE_PACKAGE not in interfaces
+    assert len(interfaces[INTERFACE_PACKAGE]) > 0
+
+    # unknown package name
+    with pytest.raises(LookupError):
+        get_service_interfaces(['test_not_package_name_you_are_bad_to_use_this_name'])
+
+
+def test_get_action_interfaces():
+    # no input
+    interfaces = get_action_interfaces()
+    assert len(interfaces) > 0
+    assert INTERFACE_PACKAGE in interfaces
+    assert NON_INTERFACE_PACKAGE not in interfaces
+    assert len(interfaces[INTERFACE_PACKAGE]) > 0
+
+    # one package
+    interfaces = get_action_interfaces([INTERFACE_PACKAGE])
+    assert len(interfaces) > 0
+    assert INTERFACE_PACKAGE in interfaces
+    assert NON_INTERFACE_PACKAGE not in interfaces
+    assert len(interfaces[INTERFACE_PACKAGE]) > 0
+
+    # multiple packages
+    interfaces = get_action_interfaces([INTERFACE_PACKAGE, NON_INTERFACE_PACKAGE])
+    assert len(interfaces) > 0
+    assert INTERFACE_PACKAGE in interfaces
+    assert NON_INTERFACE_PACKAGE not in interfaces
+    assert len(interfaces[INTERFACE_PACKAGE]) > 0
+
+    # unknown package name
+    with pytest.raises(LookupError):
+        get_action_interfaces(['test_not_package_name_you_are_bad_to_use_this_name'])
+
+
+def test_get_interface_path():
+    # get message with suffix
+    interface_path = get_interface_path('test_msgs/msg/BasicTypes.msg')
+    assert os.path.exists(interface_path)
+    assert interface_path[-4:] == '.msg'
+
+    # get message without suffix
+    interface_path = get_interface_path('test_msgs/msg/BasicTypes')
+    assert os.path.exists(interface_path)
+    assert interface_path[-4:] == '.msg'
+
+    # get service with suffix
+    interface_path = get_interface_path('test_msgs/srv/BasicTypes.srv')
+    assert os.path.exists(interface_path)
+    assert interface_path[-4:] == '.srv'
+
+    # get service without suffix
+    interface_path = get_interface_path('test_msgs/srv/BasicTypes')
+    assert os.path.exists(interface_path)
+    assert interface_path[-4:] == '.srv'
+
+    # get action with suffix
+    interface_path = get_interface_path('test_msgs/action/Fibonacci.action')
+    assert os.path.exists(interface_path)
+    assert interface_path[-7:] == '.action'
+
+    # get action without suffix
+    interface_path = get_interface_path('test_msgs/action/Fibonacci')
+    assert os.path.exists(interface_path)
+    assert interface_path[-7:] == '.action'
+
+    # get message with .idl suffix
+    interface_path = get_interface_path('test_msgs/msg/BasicTypes.idl')
+    assert os.path.exists(interface_path)
+    assert interface_path[-4:] == '.idl'


### PR DESCRIPTION
The implementation was copied from ros2/ros2cli (0de8f53) and then refactored (1ce5a76).

Since these functions are specific to rosidl, this package seems like a more appropriate place for them to live.
This will also let them be easier reused by several of the ros2cli packages (and potentially elsewhere in the future).

I'll follow-up shortly with a PR to ros2/ros2cli to make use of the implementation in this package.

~~I'm opening for visibility and early review while I add unit tests.~~ (unit tests added)

I should add that this should resolve many TODOs in the ros2cli repository, for example:

https://github.com/ros2/ros2cli/blob/80921ce1577277ef4a68184d6c2cba7d63c74b95/ros2topic/ros2topic/api/__init__.py#L60

https://github.com/ros2/ros2cli/blob/80921ce1577277ef4a68184d6c2cba7d63c74b95/ros2interface/ros2interface/api/__init__.py#L99

https://github.com/ros2/ros2cli/blob/80921ce1577277ef4a68184d6c2cba7d63c74b95/ros2interface/ros2interface/api/__init__.py#L124

https://github.com/ros2/ros2cli/blob/80921ce1577277ef4a68184d6c2cba7d63c74b95/ros2interface/ros2interface/api/__init__.py#L149

https://github.com/ros2/ros2cli/blob/80921ce1577277ef4a68184d6c2cba7d63c74b95/ros2interface/ros2interface/api/__init__.py#L162