### PR TITLE
Fix get_interfaces() implementation

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -18,6 +18,8 @@
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_xmllint</test_depend>
   <test_depend>python3-pytest</test_depend>
+  <test_depend>std_msgs</test_depend>
+  <test_depend>std_srvs</test_depend>
   <test_depend>test_msgs</test_depend>
 
   <export>

--- a/rosidl_runtime_py/get_interfaces.py
+++ b/rosidl_runtime_py/get_interfaces.py
@@ -59,11 +59,13 @@ def get_interfaces(package_names: Iterable[str] = []) -> Dict[str, List[str]]:
     # filter out hidden interfaces
     filtered_interfaces = {}
     for package_name, interface_names in interfaces.items():
-        filtered_interfaces[package_name] = list({
+        _interfaces = list({
             interface_name.rsplit('.', 1)[0]
             for interface_name in interface_names
             if '_' not in interface_name
         })
+        if _interfaces:
+            filtered_interfaces[package_name] = _interfaces
     return filtered_interfaces
 
 
@@ -83,13 +85,15 @@ def get_message_interfaces(package_names: Iterable[str] = []) -> List[str]:
     # filter out hidden interfaces and identify message interfaces by the namespace and suffix
     filtered_interfaces = {}
     for package_name, interface_names in interfaces.items():
-        filtered_interfaces[package_name] = list({
+        message_interfaces = list({
             interface_name[4:-4]
             for interface_name in interface_names
             if '_' not in interface_name and
             interface_name.startswith('msg/') and
             interface_name[-4:] in ('.idl', '.msg')
         })
+        if message_interfaces:
+            filtered_interfaces[package_name] = message_interfaces
     return filtered_interfaces
 
 
@@ -109,13 +113,15 @@ def get_service_interfaces(package_names: Iterable[str] = []) -> List[str]:
     # filter out hidden interfaces and identify service interfaces by the namespace and suffix
     filtered_interfaces = {}
     for package_name, interface_names in interfaces.items():
-        filtered_interfaces[package_name] = list({
+        service_interfaces = list({
             interface_name[4:-4]
             for interface_name in interface_names
             if '_' not in interface_name and
             interface_name.startswith('srv/') and
             interface_name[-4:] in ('.idl', '.srv')
         })
+        if service_interfaces:
+            filtered_interfaces[package_name] = service_interfaces
     return filtered_interfaces
 
 
@@ -135,13 +141,15 @@ def get_action_interfaces(package_names: Iterable[str] = []) -> List[str]:
     # filter out hidden interfaces and identify action interfaces by the namespace and suffix
     filtered_interfaces = {}
     for package_name, interface_names in interfaces.items():
-        filtered_interfaces[package_name] = list({
+        action_interfaces = list({
             interface_name[7:].rsplit('.', 1)[0]
             for interface_name in interface_names
             if '_' not in interface_name and
             interface_name.startswith('action/') and
             (interface_name[-4:] == '.idl' or interface_name[-7:] == '.action')
         })
+        if action_interfaces:
+            filtered_interfaces[package_name] = action_interfaces
     return filtered_interfaces
 
 

--- a/test/rosidl_runtime_py/test_get_interfaces.py
+++ b/test/rosidl_runtime_py/test_get_interfaces.py
@@ -25,6 +25,8 @@ from rosidl_runtime_py import get_service_interfaces
 
 # these packages are listed as dependencies in the package.xml
 INTERFACE_PACKAGE = 'test_msgs'
+MESSAGE_INTERFACE_ONLY_PACKAGE = 'std_msgs'
+SERVICE_INTERFACE_ONLY_PACKAGE = 'std_srvs'
 NON_INTERFACE_PACKAGE = 'rosidl_parser'
 
 
@@ -32,6 +34,8 @@ def test_get_interface_packages():
     packages = get_interface_packages()
     assert len(packages) > 0
     assert INTERFACE_PACKAGE in packages
+    assert MESSAGE_INTERFACE_ONLY_PACKAGE in packages
+    assert SERVICE_INTERFACE_ONLY_PACKAGE in packages
     assert NON_INTERFACE_PACKAGE not in packages
 
 
@@ -51,9 +55,16 @@ def test_get_interfaces():
     assert len(interfaces[INTERFACE_PACKAGE]) > 0
 
     # multiple packages
-    interfaces = get_interfaces([INTERFACE_PACKAGE, NON_INTERFACE_PACKAGE])
+    interfaces = get_interfaces([
+        INTERFACE_PACKAGE,
+        MESSAGE_INTERFACE_ONLY_PACKAGE,
+        SERVICE_INTERFACE_ONLY_PACKAGE,
+        NON_INTERFACE_PACKAGE
+    ])
     assert len(interfaces) > 0
     assert INTERFACE_PACKAGE in interfaces
+    assert MESSAGE_INTERFACE_ONLY_PACKAGE in interfaces
+    assert SERVICE_INTERFACE_ONLY_PACKAGE in interfaces
     assert NON_INTERFACE_PACKAGE not in interfaces
     assert len(interfaces[INTERFACE_PACKAGE]) > 0
 
@@ -67,6 +78,8 @@ def test_get_message_interfaces():
     interfaces = get_message_interfaces()
     assert len(interfaces) > 0
     assert INTERFACE_PACKAGE in interfaces
+    assert MESSAGE_INTERFACE_ONLY_PACKAGE in interfaces
+    assert SERVICE_INTERFACE_ONLY_PACKAGE not in interfaces
     assert NON_INTERFACE_PACKAGE not in interfaces
     assert len(interfaces[INTERFACE_PACKAGE]) > 0
 
@@ -74,13 +87,22 @@ def test_get_message_interfaces():
     interfaces = get_message_interfaces([INTERFACE_PACKAGE])
     assert len(interfaces) > 0
     assert INTERFACE_PACKAGE in interfaces
+    assert MESSAGE_INTERFACE_ONLY_PACKAGE not in interfaces
+    assert SERVICE_INTERFACE_ONLY_PACKAGE not in interfaces
     assert NON_INTERFACE_PACKAGE not in interfaces
     assert len(interfaces[INTERFACE_PACKAGE]) > 0
 
     # multiple packages
-    interfaces = get_message_interfaces([INTERFACE_PACKAGE, NON_INTERFACE_PACKAGE])
+    interfaces = get_message_interfaces([
+        INTERFACE_PACKAGE,
+        MESSAGE_INTERFACE_ONLY_PACKAGE,
+        SERVICE_INTERFACE_ONLY_PACKAGE,
+        NON_INTERFACE_PACKAGE
+    ])
     assert len(interfaces) > 0
     assert INTERFACE_PACKAGE in interfaces
+    assert MESSAGE_INTERFACE_ONLY_PACKAGE in interfaces
+    assert SERVICE_INTERFACE_ONLY_PACKAGE not in interfaces
     assert NON_INTERFACE_PACKAGE not in interfaces
     assert len(interfaces[INTERFACE_PACKAGE]) > 0
 
@@ -94,6 +116,8 @@ def test_get_service_interfaces():
     interfaces = get_service_interfaces()
     assert len(interfaces) > 0
     assert INTERFACE_PACKAGE in interfaces
+    assert MESSAGE_INTERFACE_ONLY_PACKAGE not in interfaces
+    assert SERVICE_INTERFACE_ONLY_PACKAGE in interfaces
     assert NON_INTERFACE_PACKAGE not in interfaces
     assert len(interfaces[INTERFACE_PACKAGE]) > 0
 
@@ -101,13 +125,22 @@ def test_get_service_interfaces():
     interfaces = get_service_interfaces([INTERFACE_PACKAGE])
     assert len(interfaces) > 0
     assert INTERFACE_PACKAGE in interfaces
+    assert MESSAGE_INTERFACE_ONLY_PACKAGE not in interfaces
+    assert SERVICE_INTERFACE_ONLY_PACKAGE not in interfaces
     assert NON_INTERFACE_PACKAGE not in interfaces
     assert len(interfaces[INTERFACE_PACKAGE]) > 0
 
     # multiple packages
-    interfaces = get_service_interfaces([INTERFACE_PACKAGE, NON_INTERFACE_PACKAGE])
+    interfaces = get_service_interfaces([
+        INTERFACE_PACKAGE,
+        MESSAGE_INTERFACE_ONLY_PACKAGE,
+        SERVICE_INTERFACE_ONLY_PACKAGE,
+        NON_INTERFACE_PACKAGE
+    ])
     assert len(interfaces) > 0
     assert INTERFACE_PACKAGE in interfaces
+    assert MESSAGE_INTERFACE_ONLY_PACKAGE not in interfaces
+    assert SERVICE_INTERFACE_ONLY_PACKAGE in interfaces
     assert NON_INTERFACE_PACKAGE not in interfaces
     assert len(interfaces[INTERFACE_PACKAGE]) > 0
 
@@ -121,6 +154,8 @@ def test_get_action_interfaces():
     interfaces = get_action_interfaces()
     assert len(interfaces) > 0
     assert INTERFACE_PACKAGE in interfaces
+    assert MESSAGE_INTERFACE_ONLY_PACKAGE not in interfaces
+    assert SERVICE_INTERFACE_ONLY_PACKAGE not in interfaces
     assert NON_INTERFACE_PACKAGE not in interfaces
     assert len(interfaces[INTERFACE_PACKAGE]) > 0
 
@@ -128,6 +163,8 @@ def test_get_action_interfaces():
     interfaces = get_action_interfaces([INTERFACE_PACKAGE])
     assert len(interfaces) > 0
     assert INTERFACE_PACKAGE in interfaces
+    assert MESSAGE_INTERFACE_ONLY_PACKAGE not in interfaces
+    assert SERVICE_INTERFACE_ONLY_PACKAGE not in interfaces
     assert NON_INTERFACE_PACKAGE not in interfaces
     assert len(interfaces[INTERFACE_PACKAGE]) > 0
 
@@ -135,6 +172,8 @@ def test_get_action_interfaces():
     interfaces = get_action_interfaces([INTERFACE_PACKAGE, NON_INTERFACE_PACKAGE])
     assert len(interfaces) > 0
     assert INTERFACE_PACKAGE in interfaces
+    assert MESSAGE_INTERFACE_ONLY_PACKAGE not in interfaces
+    assert SERVICE_INTERFACE_ONLY_PACKAGE not in interfaces
     assert NON_INTERFACE_PACKAGE not in interfaces
     assert len(interfaces[INTERFACE_PACKAGE]) > 0
 


### PR DESCRIPTION
Drop packages that have no interfaces after filtering. Follow-up PR after #3.