### PR TITLE
Limit the interface path to prevent security issues.

### DIFF
--- a/rosidl_runtime_py/get_interfaces.py
+++ b/rosidl_runtime_py/get_interfaces.py
@@ -179,8 +179,6 @@ def get_interface_path(interface_name: str) -> str:
         raise LookupError(f"Unknown package '{parts[0]}'")
 
     interface_path = os.path.join(prefix_path, 'share', interface_name)
-    if not parts[-2] in ['msg', 'srv', 'action']:
-        raise ValueError(f"Namespace should be 'msg', 'srv' or 'action'")
     # Check if there is a dot-separated suffix
     if len(parts[-1].rsplit('.', 1)) == 1:
         # If there is no suffix, try appending parent namespace (e.g. '.msg', '.srv', '.action')

--- a/rosidl_runtime_py/get_interfaces.py
+++ b/rosidl_runtime_py/get_interfaces.py
@@ -171,12 +171,16 @@ def get_interface_path(interface_name: str) -> str:
             f"Invalid name '{interface_name}'. Expected at least two parts separated by '/'")
     if not all(parts):
         raise ValueError(f"Invalid name '{interface_name}'. Must not contain empty parts")
+    if '..' in parts:
+        raise ValueError(f"Must not contain '..'")
     # By convention we expect the first part to be the package name
     prefix_path = has_resource('packages', parts[0])
     if not prefix_path:
         raise LookupError(f"Unknown package '{parts[0]}'")
 
     interface_path = os.path.join(prefix_path, 'share', interface_name)
+    if not parts[-2] in ['msg', 'srv', 'action']:
+        raise ValueError(f"Namespace should be 'msg', 'srv' or 'action'")
     # Check if there is a dot-separated suffix
     if len(parts[-1].rsplit('.', 1)) == 1:
         # If there is no suffix, try appending parent namespace (e.g. '.msg', '.srv', '.action')

--- a/rosidl_runtime_py/get_interfaces.py
+++ b/rosidl_runtime_py/get_interfaces.py
@@ -172,7 +172,7 @@ def get_interface_path(interface_name: str) -> str:
     if not all(parts):
         raise ValueError(f"Invalid name '{interface_name}'. Must not contain empty parts")
     if '..' in parts:
-        raise ValueError(f"Must not contain '..'")
+        raise ValueError(f"Invalid name '{interface_name}'. Must not contain '..'")
     # By convention we expect the first part to be the package name
     prefix_path = has_resource('packages', parts[0])
     if not prefix_path:


### PR DESCRIPTION
I found that there might be a security issue when trying to use `ros interface`. I can get the content of any files by adding `..`. For example:
```
ros2 interface show std_msgs/../../../../install/local_setup.bash
```
I think this is not what we want, so I add some limitations into `get_interface_path`, including no `..` in path and the namespace should be `msg`, `srv` or `action`.
I'm not sure whether the namespace should always be one of `msg`, `srv` or `action`. Please tell me if I'm wrong.