### PR TITLE
Add special case for importing action feedback message

### DIFF
--- a/rosidl_runtime_py/import_message.py
+++ b/rosidl_runtime_py/import_message.py
@@ -32,7 +32,7 @@ def import_message_from_namespaced_type(message_type: NamespacedType) -> Any:
 
     # Special case for action feedback
     if message_type.name.endswith('_FeedbackMessage'):
-        action_name, name = message_type.name.split('_', 1)
+        action_name, name = message_type.name.rsplit('_', 1)
         return getattr(getattr(getattr(module, action_name), 'Impl'), name)
 
     return getattr(module, message_type.name)

--- a/rosidl_runtime_py/import_message.py
+++ b/rosidl_runtime_py/import_message.py
@@ -29,4 +29,10 @@ def import_message_from_namespaced_type(message_type: NamespacedType) -> Any:
                 DeprecationWarning)
     module = importlib.import_module(
         '.'.join(message_type.namespaces))
+
+    # Special case for action feedback
+    if message_type.name.endswith('_FeedbackMessage'):
+        action_name, name = message_type.name.split('_', 1)
+        return getattr(getattr(getattr(module, action_name), 'Impl'), name)
+
     return getattr(module, message_type.name)

--- a/test/rosidl_runtime_py/test_import_message.py
+++ b/test/rosidl_runtime_py/test_import_message.py
@@ -20,6 +20,7 @@ from rosidl_parser.definition import UnboundedSequence
 
 from rosidl_runtime_py.import_message import import_message_from_namespaced_type
 
+from test_msgs.action._fibonacci import Fibonacci_FeedbackMessage
 from test_msgs.msg import Empty
 
 
@@ -38,3 +39,9 @@ def test_import_namespaced_type():
         assert len(w) == 1
         assert issubclass(w[0].category, DeprecationWarning)
     assert type(imported_message2) == type(Empty)
+
+
+def test_import_namespaced_type_feedback_message():
+    feedback_namespaced_type = NamespacedType(['test_msgs', 'action'], 'Fibonacci_FeedbackMessage')
+    imported_message = import_message_from_namespaced_type(feedback_namespaced_type)
+    assert type(imported_message) == type(Fibonacci_FeedbackMessage)


### PR DESCRIPTION
This is to support getting the feedback message type used to communicate between action servers and action clients.
The feedback message type can be used to introspect action goals with tools like ros2topic.

Note that currently, `ros2 topic echo` does not work with action feedback topics. I'll have a PR to https://github.com/ros2/ros2cli shortly that makes use of the import function modified here.

Maybe it makes sense to push this logic into `rosidl_parser`, but this gets the job done for now.