### PR TITLE
Support converting serialized messages

### DIFF
--- a/rosidl_runtime_py/convert.py
+++ b/rosidl_runtime_py/convert.py
@@ -104,6 +104,8 @@ def message_to_csv(
     """
     Convert a ROS message to string of comma-separated values.
 
+    If the message is serialized, then a single string of bytes is returned.
+
     :param msg: The ROS message to convert.
     :param truncate_length: Truncate values for all message fields to this length.
         This does not truncate the list of message fields.
@@ -141,6 +143,10 @@ def message_to_csv(
         return r
     result = ''
 
+    # Special case: if the message is serialized, then return the bytes as a string
+    if isinstance(msg, bytes):
+        return str(msg)
+
     # We rely on __slots__ retaining the order of the fields in the .msg file.
     for field_name, field_type in zip(msg.__slots__, msg.SLOT_TYPES):
         value = getattr(msg, field_name)
@@ -164,6 +170,9 @@ def message_to_ordereddict(
     """
     Convert a ROS message to an OrderedDict.
 
+    If the message is serialized, then the returned dictionary will only contain one entry
+    named 'bytes' containing the binary data that is the message.
+
     :param msg: The ROS message to convert.
     :param truncate_length: Truncate values for all message fields to this length.
         This does not truncate the list of fields (ie. the dictionary keys).
@@ -173,6 +182,11 @@ def message_to_ordereddict(
         set to the values of the input message.
     """
     d = OrderedDict()
+
+    # Special case: if the message is serialized, then return a single field containing the bytes
+    if isinstance(msg, bytes):
+        d['bytes'] = msg
+        return d
 
     # We rely on __slots__ retaining the order of the fields in the .msg file.
     for field_name, field_type in zip(msg.__slots__, msg.SLOT_TYPES):

--- a/test/rosidl_runtime_py/test_convert.py
+++ b/test/rosidl_runtime_py/test_convert.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import base64
 from collections import OrderedDict
 
 from rosidl_runtime_py import message_to_csv
@@ -111,3 +112,24 @@ def test_convert_dict():
     assert {1: 'a', '2': 'b'} == _convert_value({1: 'a', '2': 'b'}, truncate_length=1000)
     assert {1: 'a...', '234': 'b...'} == _convert_value(
         {1: 'abc', '234': 'bcd'}, truncate_length=1)
+
+
+def test_convert_serialized_message_ordered_dict():
+    serialized_data = b'\xce\xbb'
+    result = message_to_ordereddict(serialized_data)
+    assert 'bytes' in result
+    assert result['bytes'] == serialized_data
+
+
+def test_convert_serialized_message_yaml():
+    serialized_data = b'\xce\xbb'
+    # YAML uses base64 encoding
+    base64_data = base64.b64encode(serialized_data)
+    result = message_to_yaml(serialized_data)
+    assert base64_data.decode() in result
+
+
+def test_convert_serialized_message_to_csv():
+    serialized_data = b'\xce\xbb'
+    result = message_to_csv(serialized_data)
+    assert result == str(serialized_data)


### PR DESCRIPTION
This requires adding special cases for handling serialized messages to some of the conversion functions.
Behavior is documented and unit tested.