### PR TITLE
improve exception message if value doesn't match expected type

### DIFF
--- a/rosidl_runtime_py/set_message.py
+++ b/rosidl_runtime_py/set_message.py
@@ -33,9 +33,15 @@ def set_message_fields(msg: Any, values: Dict[str, str]) -> None:
     :param values: The values to set in the ROS message. The keys of the dictionary represent
         fields of the message.
     :raises AttributeError: If the message does not have a field provided in the input dictionary.
-    :raises ValueError: If a message value does not match its field type.
+    :raises TypeError: If a message value does not match its field type.
     """
-    for field_name, field_value in values.items():
+    try:
+        items = values.items()
+    except AttributeError:
+        raise TypeError(
+            "Value '%s' is expected to be a dictionary but is a %s" %
+            (values, type(values).__name__))
+    for field_name, field_value in items:
         field = getattr(msg, field_name)
         field_type = type(field)
         if field_type is array.array:

--- a/test/rosidl_runtime_py/test_set_message.py
+++ b/test/rosidl_runtime_py/test_set_message.py
@@ -92,6 +92,10 @@ def test_set_message_fields_invalid():
     with pytest.raises(ValueError):
         set_message_fields(msg, invalid_type)
 
+    msg = message_fixtures.get_msg_nested()[0]
+    with pytest.raises(TypeError):
+        set_message_fields(msg, 'not_a_dict')
+
 
 def test_set_nested_namespaced_fields():
     unbounded_sequence_msg = message_fixtures.get_msg_unbounded_sequences()[1]


### PR DESCRIPTION
Example command:

    ros2 topic pub -1 /goal geometry_msgs/PoseStamped '{header: {stamp: now, frame_id: "odom"}, pose: {position: {x: -2.0, y: 2.0, z: 0.0}, orientation: {w: 1.0}}}'