### PR TITLE
Expand timestamps for std_msgs.msg.Header and builtin_interfaces.msg.Time if 'auto' and 'now' are passed as values

### DIFF
--- a/rosidl_runtime_py/set_message.py
+++ b/rosidl_runtime_py/set_message.py
@@ -13,9 +13,11 @@
 # limitations under the License.
 
 import array
+from functools import partial
 
 from typing import Any
 from typing import Dict
+from typing import List
 
 import numpy
 
@@ -25,44 +27,76 @@ from rosidl_runtime_py.convert import get_message_slot_types
 from rosidl_runtime_py.import_message import import_message_from_namespaced_type
 
 
-def set_message_fields(msg: Any, values: Dict[str, str]) -> None:
+def set_message_fields(
+        msg: Any, values: Dict[str, str], expand_header_auto: bool = False,
+        expand_time_now: bool = False) -> List[Any]:
     """
     Set the fields of a ROS message.
 
     :param msg: The ROS message to populate.
     :param values: The values to set in the ROS message. The keys of the dictionary represent
         fields of the message.
+    :param expand_header_auto: If enabled and 'auto' is passed as a value to a
+        'std_msgs.msg.Header' field, an empty Header will be instantiated and a setter function
+        will be returned so that its 'stamp' field can be set to the current time.
+    :param expand_time_now: If enabled and 'now' is passed as a value to a
+        'builtin_interfaces.msg.Time' field, a setter function will be returned so that
+        its value can be set to the current time.
+    :returns: A list of setter functions that can be used to update 'builtin_interfaces.msg.Time'
+        fields, useful for setting them to the current time. The list will be empty if the message
+        does not have any 'builtin_interfaces.msg.Time' fields, or if expand_header_auto and
+        expand_time_now are false.
     :raises AttributeError: If the message does not have a field provided in the input dictionary.
     :raises TypeError: If a message value does not match its field type.
     """
-    try:
-        items = values.items()
-    except AttributeError:
-        raise TypeError(
-            "Value '%s' is expected to be a dictionary but is a %s" %
-            (values, type(values).__name__))
-    for field_name, field_value in items:
-        field = getattr(msg, field_name)
-        field_type = type(field)
-        if field_type is array.array:
-            value = field_type(field.typecode, field_value)
-        elif field_type is numpy.ndarray:
-            value = numpy.array(field_value, dtype=field.dtype)
-        elif type(field_value) is field_type:
-            value = field_value
-        else:
-            try:
-                value = field_type(field_value)
-            except TypeError:
-                value = field_type()
-                set_message_fields(value, field_value)
-        rosidl_type = get_message_slot_types(msg)[field_name]
-        # Check if field is an array of ROS messages
-        if isinstance(rosidl_type, AbstractNestedType):
-            if isinstance(rosidl_type.value_type, NamespacedType):
-                field_elem_type = import_message_from_namespaced_type(rosidl_type.value_type)
-                for n in range(len(value)):
-                    submsg = field_elem_type()
-                    set_message_fields(submsg, value[n])
-                    value[n] = submsg
-        setattr(msg, field_name, value)
+    timestamp_fields = []
+
+    def set_message_fields_internal(
+            msg: Any, values: Dict[str, str],
+            timestamp_fields: List[Any]) -> List[Any]:
+        try:
+            items = values.items()
+        except AttributeError:
+            raise TypeError(
+                "Value '%s' is expected to be a dictionary but is a %s" %
+                (values, type(values).__name__))
+        for field_name, field_value in items:
+            field = getattr(msg, field_name)
+            field_type = type(field)
+            qualified_class_name = '{}.{}'.format(field_type.__module__, field_type.__name__)
+            if field_type is array.array:
+                value = field_type(field.typecode, field_value)
+            elif field_type is numpy.ndarray:
+                value = numpy.array(field_value, dtype=field.dtype)
+            elif type(field_value) is field_type:
+                value = field_value
+            # We can't import these types directly, so we use the qualified class name to
+            # distinguish them from other fields
+            elif qualified_class_name == 'std_msgs.msg._header.Header' and \
+                    field_value == 'auto' and expand_header_auto:
+                timestamp_fields.append(partial(setattr, field, 'stamp'))
+                continue
+            elif qualified_class_name == 'builtin_interfaces.msg._time.Time' and \
+                    field_value == 'now' and expand_time_now:
+                timestamp_fields.append(partial(setattr, msg, field_name))
+                continue
+            else:
+                try:
+                    value = field_type(field_value)
+                except TypeError:
+                    value = field_type()
+                    set_message_fields_internal(
+                        value, field_value, timestamp_fields)
+            rosidl_type = get_message_slot_types(msg)[field_name]
+            # Check if field is an array of ROS messages
+            if isinstance(rosidl_type, AbstractNestedType):
+                if isinstance(rosidl_type.value_type, NamespacedType):
+                    field_elem_type = import_message_from_namespaced_type(rosidl_type.value_type)
+                    for n in range(len(value)):
+                        submsg = field_elem_type()
+                        set_message_fields_internal(
+                            submsg, value[n], timestamp_fields)
+                        value[n] = submsg
+            setattr(msg, field_name, value)
+    set_message_fields_internal(msg, values, timestamp_fields)
+    return timestamp_fields

--- a/test/rosidl_runtime_py/test_set_message.py
+++ b/test/rosidl_runtime_py/test_set_message.py
@@ -15,9 +15,8 @@
 import builtins
 import copy
 
-import pytest
-
 from builtin_interfaces.msg import Time
+import pytest
 import rosidl_parser.definition
 from rosidl_runtime_py import set_message_fields
 from std_msgs.msg import Header

--- a/test/rosidl_runtime_py/test_set_message.py
+++ b/test/rosidl_runtime_py/test_set_message.py
@@ -233,6 +233,16 @@ def test_set_message_fields_header_auto():
     assert msg.header.frame_id == ''
 
 
+def test_set_message_fields_header_auto_not_parsed():
+    msg = MockMessageStamped()
+    values = {'header': 'auto'}
+    assert msg.header.stamp.sec == 0 and msg.header.stamp.nanosec == 0
+    assert msg.header.frame_id == ''
+    with pytest.raises(
+            TypeError, match=r"^Value 'auto' is expected to be a dictionary but is a str$"):
+        set_message_fields(msg, values)
+
+
 def test_set_message_fields_stamp_now():
     msg = MockMessageStamped()
     values = {'header': {'stamp': 'now'}}
@@ -246,6 +256,16 @@ def test_set_message_fields_stamp_now():
         field_setter(stamp)
     assert msg.header.stamp.sec == 1 and msg.header.stamp.nanosec == 2
     assert msg.header.frame_id == ''
+
+
+def test_set_message_fields_stamp_now_not_parsed():
+    msg = MockMessageStamped()
+    values = {'header': {'stamp': 'now'}}
+    assert msg.header.stamp.sec == 0 and msg.header.stamp.nanosec == 0
+    assert msg.header.frame_id == ''
+    with pytest.raises(
+            TypeError, match=r"^Value 'now' is expected to be a dictionary but is a str$"):
+        set_message_fields(msg, values)
 
 
 def test_set_message_fields_stamp_now_with_frame_id():

--- a/test/rosidl_runtime_py/test_set_message.py
+++ b/test/rosidl_runtime_py/test_set_message.py
@@ -12,12 +12,80 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import builtins
 import copy
 
 import pytest
 
+from builtin_interfaces.msg import Time
+import rosidl_parser.definition
 from rosidl_runtime_py import set_message_fields
+from std_msgs.msg import Header
 from test_msgs import message_fixtures
+
+
+class MockMessageStamped:
+
+    __slots__ = [
+        '_header',
+    ]
+
+    _fields_and_field_types = {
+        'header': 'std_msgs/Header',
+    }
+
+    SLOT_TYPES = (
+        rosidl_parser.definition.NamespacedType(['std_msgs', 'msg'], 'Header'),
+    )
+
+    def __init__(self):
+        self.header = Header()
+
+    @builtins.property
+    def header(self):
+        return self._header
+
+    @header.setter
+    def header(self, value):
+        self._header = value
+
+
+class MockMessageWithStampFields:
+
+    __slots__ = [
+        '_timestamp1',
+        '_timestamp2',
+    ]
+
+    _fields_and_field_types = {
+        'timestamp1': 'builtin_interfaces/Time',
+        'timestamp2': 'builtin_interfaces/Time',
+    }
+
+    SLOT_TYPES = (
+        rosidl_parser.definition.NamespacedType(['builtin_interfaces', 'msg'], 'Time'),
+        rosidl_parser.definition.NamespacedType(['builtin_interfaces', 'msg'], 'Time'),
+    )
+
+    def __init__(self):
+        self.timestamp1 = Time()
+        self.timestamp2 = Time()
+
+    @builtins.property
+    def timestamp1(self):
+        return self._timestamp1
+
+    @timestamp1.setter
+    def timestamp1(self, value):
+        self._timestamp1 = value
+
+    @builtins.property
+    def timestamp2(self):
+        return self._timestamp2
+
+    @timestamp2.setter
+    def timestamp2(self, value):
+        self._timestamp2 = value
 
 
 def test_set_message_fields_none():
@@ -148,3 +216,63 @@ def test_set_message_fields_nested_type():
     set_message_fields(msg0, test_values)
 
     assert msg0.basic_types_value == msg_basic_types
+
+
+def test_set_message_fields_header_auto():
+    msg = MockMessageStamped()
+    values = {'header': 'auto'}
+    assert msg.header.stamp.sec == 0 and msg.header.stamp.nanosec == 0
+    assert msg.header.frame_id == ''
+    timestamp_fields = set_message_fields(
+        msg, values, expand_header_auto=True, expand_time_now=True)
+    assert timestamp_fields is not None
+    for field_setter in timestamp_fields:
+        stamp = Time(sec=1, nanosec=2)
+        field_setter(stamp)
+    assert msg.header.stamp.sec == 1 and msg.header.stamp.nanosec == 2
+    assert msg.header.frame_id == ''
+
+
+def test_set_message_fields_stamp_now():
+    msg = MockMessageStamped()
+    values = {'header': {'stamp': 'now'}}
+    assert msg.header.stamp.sec == 0 and msg.header.stamp.nanosec == 0
+    assert msg.header.frame_id == ''
+    timestamp_fields = set_message_fields(
+        msg, values, expand_header_auto=True, expand_time_now=True)
+    assert timestamp_fields is not None
+    for field_setter in timestamp_fields:
+        stamp = Time(sec=1, nanosec=2)
+        field_setter(stamp)
+    assert msg.header.stamp.sec == 1 and msg.header.stamp.nanosec == 2
+    assert msg.header.frame_id == ''
+
+
+def test_set_message_fields_stamp_now_with_frame_id():
+    msg = MockMessageStamped()
+    values = {'header': {'stamp': 'now', 'frame_id': 'hello'}}
+    assert msg.header.stamp.sec == 0 and msg.header.stamp.nanosec == 0
+    assert msg.header.frame_id == ''
+    timestamp_fields = set_message_fields(
+        msg, values, expand_header_auto=True, expand_time_now=True)
+    assert timestamp_fields is not None
+    for field_setter in timestamp_fields:
+        stamp = Time(sec=1, nanosec=2)
+        field_setter(stamp)
+    assert msg.header.stamp.sec == 1 and msg.header.stamp.nanosec == 2
+    assert msg.header.frame_id == 'hello'
+
+
+def test_set_message_fields_stamp_now_with_timestamp_fields():
+    msg = MockMessageWithStampFields()
+    values = {'timestamp1': 'now', 'timestamp2': 'now'}
+    assert msg.timestamp1.sec == 0 and msg.timestamp1.nanosec == 0
+    assert msg.timestamp2.sec == 0 and msg.timestamp2.nanosec == 0
+    timestamp_fields = set_message_fields(
+        msg, values, expand_header_auto=True, expand_time_now=True)
+    assert timestamp_fields is not None
+    for field_setter in timestamp_fields:
+        stamp = Time(sec=1, nanosec=2)
+        field_setter(stamp)
+    assert msg.timestamp1.sec == 1 and msg.timestamp1.nanosec == 2
+    assert msg.timestamp2.sec == 1 and msg.timestamp2.nanosec == 2


### PR DESCRIPTION
Merge the logic from https://github.com/ros2/ros2cli/pull/749 into `set_message_fields`

Closes https://github.com/ros2/ros2cli/issues/700