### PR TITLE
Speedup conversion of arrays and numpy arrays

### DIFF
--- a/rosidl_runtime_py/convert.py
+++ b/rosidl_runtime_py/convert.py
@@ -211,6 +211,8 @@ def _convert_value(
             value = '<string length: <{0}>>'.format(len(value))
         elif truncate_length is not None and len(value) > truncate_length:
             value = value[:truncate_length] + '...'
+    elif isinstance(value, (array.array, numpy.ndarray)) and not no_arr and truncate_length is None:
+        value = value.tolist()
     elif isinstance(value, (list, tuple, array.array, numpy.ndarray)):
         # Since arrays and ndarrays can't contain mixed types convert to list
         typename = tuple if isinstance(value, tuple) else list

--- a/rosidl_runtime_py/convert.py
+++ b/rosidl_runtime_py/convert.py
@@ -187,7 +187,7 @@ def message_to_ordereddict(
         value = getattr(msg, field_name, None)
         value = _convert_value(
             value, field_type=field_type,
-            truncate_len=truncate_length, no_arr=no_arr, no_str=no_str)
+            truncate_length=truncate_length, no_arr=no_arr, no_str=no_str)
         d[field_name] = value
     return d
 
@@ -196,39 +196,39 @@ def _convert_value(
     value,
     *,
     field_type=None,
-    truncate_len=None,
+    truncate_length=None,
     no_arr=False,
     no_str=False
 ):
 
     if isinstance(value, bytes):
-        if truncate_len is not None and len(value) > truncate_len:
-            value = ''.join([chr(c) for c in value[:truncate_len]]) + '...'
+        if truncate_length is not None and len(value) > truncate_length:
+            value = ''.join([chr(c) for c in value[:truncate_length]]) + '...'
         else:
             value = ''.join([chr(c) for c in value])
     elif isinstance(value, str):
         if no_str is True:
             value = '<string length: <{0}>>'.format(len(value))
-        elif truncate_len is not None and len(value) > truncate_len:
-            value = value[:truncate_len] + '...'
-    elif isinstance(value, (array.array, numpy.ndarray)) and not no_arr and truncate_len is None:
+        elif truncate_length is not None and len(value) > truncate_length:
+            value = value[:truncate_length] + '...'
+    elif isinstance(value, (array.array, numpy.ndarray)) and not no_arr and truncate_length is None:
         value = value.tolist()
     elif isinstance(value, (list, tuple, array.array, numpy.ndarray)):
         # Since arrays and ndarrays can't contain mixed types convert to list
         typename = tuple if isinstance(value, tuple) else list
         if no_arr is True and field_type is not None:
             value = __abbreviate_array_info(value, field_type)
-        elif truncate_len is not None and len(value) > truncate_len:
+        elif truncate_length is not None and len(value) > truncate_length:
             # Truncate the sequence
-            value = value[:truncate_len]
+            value = value[:truncate_length]
             # Truncate every item in the sequence
             value = typename(
-                [_convert_value(v, truncate_len=truncate_len,
+                [_convert_value(v, truncate_length=truncate_length,
                                 no_arr=no_arr, no_str=no_str) for v in value] + ['...'])
         else:
             # Truncate every item in the list
             value = typename(
-                [_convert_value(v, truncate_len=truncate_len,
+                [_convert_value(v, truncate_length=truncate_length,
                                 no_arr=no_arr, no_str=no_str) for v in value])
     elif isinstance(value, dict) or isinstance(value, OrderedDict):
         # Convert each key and value in the mapping
@@ -236,14 +236,14 @@ def _convert_value(
         for k, v in value.items():
             # Don't truncate keys because that could result in key collisions and data loss
             new_value[_convert_value(k)] = _convert_value(
-                v, truncate_len=truncate_len, no_arr=no_arr, no_str=no_str)
+                v, truncate_length=truncate_length, no_arr=no_arr, no_str=no_str)
         value = new_value
     elif isinstance(value, numpy.number):
         value = value.item()
     elif not isinstance(value, (bool, float, int)):
         # Assuming value is a message since it is neither a collection nor a primitive type
         value = message_to_ordereddict(
-            value, truncate_length=truncate_len, no_arr=no_arr, no_str=no_str)
+            value, truncate_length=truncate_length, no_arr=no_arr, no_str=no_str)
     return value
 
 

--- a/rosidl_runtime_py/convert.py
+++ b/rosidl_runtime_py/convert.py
@@ -187,7 +187,7 @@ def message_to_ordereddict(
         value = getattr(msg, field_name, None)
         value = _convert_value(
             value, field_type=field_type,
-            truncate_length=truncate_length, no_arr=no_arr, no_str=no_str)
+            truncate_len=truncate_length, no_arr=no_arr, no_str=no_str)
         d[field_name] = value
     return d
 
@@ -196,39 +196,39 @@ def _convert_value(
     value,
     *,
     field_type=None,
-    truncate_length=None,
+    truncate_len=None,
     no_arr=False,
     no_str=False
 ):
 
     if isinstance(value, bytes):
-        if truncate_length is not None and len(value) > truncate_length:
-            value = ''.join([chr(c) for c in value[:truncate_length]]) + '...'
+        if truncate_len is not None and len(value) > truncate_len:
+            value = ''.join([chr(c) for c in value[:truncate_len]]) + '...'
         else:
             value = ''.join([chr(c) for c in value])
     elif isinstance(value, str):
         if no_str is True:
             value = '<string length: <{0}>>'.format(len(value))
-        elif truncate_length is not None and len(value) > truncate_length:
-            value = value[:truncate_length] + '...'
-    elif isinstance(value, (array.array, numpy.ndarray)) and not no_arr and truncate_length is None:
+        elif truncate_len is not None and len(value) > truncate_len:
+            value = value[:truncate_len] + '...'
+    elif isinstance(value, (array.array, numpy.ndarray)) and not no_arr and truncate_len is None:
         value = value.tolist()
     elif isinstance(value, (list, tuple, array.array, numpy.ndarray)):
         # Since arrays and ndarrays can't contain mixed types convert to list
         typename = tuple if isinstance(value, tuple) else list
         if no_arr is True and field_type is not None:
             value = __abbreviate_array_info(value, field_type)
-        elif truncate_length is not None and len(value) > truncate_length:
+        elif truncate_len is not None and len(value) > truncate_len:
             # Truncate the sequence
-            value = value[:truncate_length]
+            value = value[:truncate_len]
             # Truncate every item in the sequence
             value = typename(
-                [_convert_value(v, truncate_length=truncate_length,
+                [_convert_value(v, truncate_len=truncate_len,
                                 no_arr=no_arr, no_str=no_str) for v in value] + ['...'])
         else:
             # Truncate every item in the list
             value = typename(
-                [_convert_value(v, truncate_length=truncate_length,
+                [_convert_value(v, truncate_len=truncate_len,
                                 no_arr=no_arr, no_str=no_str) for v in value])
     elif isinstance(value, dict) or isinstance(value, OrderedDict):
         # Convert each key and value in the mapping
@@ -236,14 +236,14 @@ def _convert_value(
         for k, v in value.items():
             # Don't truncate keys because that could result in key collisions and data loss
             new_value[_convert_value(k)] = _convert_value(
-                v, truncate_length=truncate_length, no_arr=no_arr, no_str=no_str)
+                v, truncate_len=truncate_len, no_arr=no_arr, no_str=no_str)
         value = new_value
     elif isinstance(value, numpy.number):
         value = value.item()
     elif not isinstance(value, (bool, float, int)):
         # Assuming value is a message since it is neither a collection nor a primitive type
         value = message_to_ordereddict(
-            value, truncate_length=truncate_length, no_arr=no_arr, no_str=no_str)
+            value, truncate_length=truncate_len, no_arr=no_arr, no_str=no_str)
     return value
 
 

--- a/rosidl_runtime_py/convert.py
+++ b/rosidl_runtime_py/convert.py
@@ -211,7 +211,11 @@ def _convert_value(
             value = '<string length: <{0}>>'.format(len(value))
         elif truncate_length is not None and len(value) > truncate_length:
             value = value[:truncate_length] + '...'
-    elif isinstance(value, (array.array, numpy.ndarray)) and not no_arr and truncate_length is None:
+    elif (
+        isinstance(value, (array.array, numpy.ndarray))
+        and not no_arr
+        and truncate_length is None
+    ):
         value = value.tolist()
     elif isinstance(value, (list, tuple, array.array, numpy.ndarray)):
         # Since arrays and ndarrays can't contain mixed types convert to list


### PR DESCRIPTION
The `_convert_value` function takes a lot of time converting array types, especially making conversion of image types very slow. This change accelerates this conversion when the complete images are handled (`no_arr` option is off, no truncation applied).

Example for speedup:
- Before change:
```
$ python -m timeit -s "from rosidl_runtime_py import message_to_ordereddict; from sensor_msgs.msg import CompressedImage; img = CompressedImage(data=range(256))" -n 100000 "message_to_ordereddict(img)"
100000 loops, best of 5: 149 usec per loop
```
- After change:
```
$ python -m timeit -s "from rosidl_runtime_py import message_to_ordereddict; from sensor_msgs.msg import CompressedImage; img = CompressedImage(data=range(256))" -n 100000 "message_to_ordereddict(img)"
100000 loops, best of 5: 11.7 usec per loop
```
The conversion time went down for a compressed image of 256 bytes more than 10 folds, with possibly higher gains at reasonable image sizes.