### PR TITLE
fix(set_message): encode strings if field is bytes

### DIFF
--- a/rosidl_runtime_py/set_message.py
+++ b/rosidl_runtime_py/set_message.py
@@ -28,7 +28,7 @@ from rosidl_runtime_py.import_message import import_message_from_namespaced_type
 
 
 def set_message_fields(
-        msg: Any, values: Dict[str, str], expand_header_auto: bool = False,
+        msg: Any, values: Dict[str, Any], expand_header_auto: bool = False,
         expand_time_now: bool = False) -> List[Any]:
     """
     Set the fields of a ROS message.
@@ -52,7 +52,7 @@ def set_message_fields(
     timestamp_fields = []
 
     def set_message_fields_internal(
-            msg: Any, values: Dict[str, str],
+            msg: Any, values: Dict[str, Any],
             timestamp_fields: List[Any]) -> List[Any]:
         try:
             items = values.items()
@@ -70,6 +70,8 @@ def set_message_fields(
                 value = numpy.array(field_value, dtype=field.dtype)
             elif type(field_value) is field_type:
                 value = field_value
+            elif field_type is bytes and type(field_value) is str:
+                value = field_value.encode()
             # We can't import these types directly, so we use the qualified class name to
             # distinguish them from other fields
             elif qualified_class_name == 'std_msgs.msg._header.Header' and \

--- a/rosidl_runtime_py/set_message.py
+++ b/rosidl_runtime_py/set_message.py
@@ -71,7 +71,9 @@ def set_message_fields(
             elif type(field_value) is field_type:
                 value = field_value
             elif field_type is bytes and type(field_value) is str:
-                value = field_value.encode()
+                # value = field_value.encode()
+                value = bytes([ord(c) for c in field_value])
+                # value = bytes(field_value, 'ascii', 'backslashreplace')
             # We can't import these types directly, so we use the qualified class name to
             # distinguish them from other fields
             elif qualified_class_name == 'std_msgs.msg._header.Header' and \

--- a/test/rosidl_runtime_py/test_set_message.py
+++ b/test/rosidl_runtime_py/test_set_message.py
@@ -14,11 +14,12 @@
 
 import builtins
 import copy
+import yaml
 
 from builtin_interfaces.msg import Time
 import pytest
 import rosidl_parser.definition
-from rosidl_runtime_py import set_message_fields
+from rosidl_runtime_py import set_message_fields, message_to_yaml
 from std_msgs.msg import Header
 from test_msgs import message_fixtures
 
@@ -138,6 +139,18 @@ def test_set_message_fields_partial():
             assert getattr(modified_msg, attr) == values[attr]
         else:
             assert getattr(modified_msg, attr) == getattr(original_msg, attr)
+
+
+def test_set_message_fields_from_yaml():
+    original_msg = message_fixtures.get_msg_basic_types()[1]
+    original_yaml = message_to_yaml(original_msg)
+    values = yaml.safe_load(original_yaml)
+
+    modified_msg = copy.copy(message_fixtures.get_msg_basic_types()[0])
+    set_message_fields(modified_msg, values)
+
+    for attr in original_msg.get_fields_and_field_types().keys():
+        assert getattr(modified_msg, attr) == getattr(original_msg, attr)
 
 
 def test_set_message_fields_full():


### PR DESCRIPTION
I was trying to load yaml that was output from `ros2 topic echo` and then convert them back into msgs for fixtures, and I came across this issue:

```
Traceback (most recent call last):
  File "/opt/ros/jazzy/lib/python3.12/site-packages/rosidl_runtime_py/set_message.py", line 85, in set_message_fields_internal
    value = field_type(field_value)
            ^^^^^^^^^^^^^^^^^^^^^^^
TypeError: string argument without an encoding

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/ros/jazzy/lib/python3.12/site-packages/rosidl_runtime_py/set_message.py", line 58, in set_message_fields_internal
    items = values.items()
            ^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'items'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/ros/jazzy/lib/python3.12/site-packages/rosidl_runtime_py/set_message.py", line 101, in set_message_fields
    set_message_fields_internal(msg, values, timestamp_fields)
  File "/opt/ros/jazzy/lib/python3.12/site-packages/rosidl_runtime_py/set_message.py", line 97, in set_message_fields_internal
    set_message_fields_internal(
  File "/opt/ros/jazzy/lib/python3.12/site-packages/rosidl_runtime_py/set_message.py", line 88, in set_message_fields_internal
    set_message_fields_internal(
  File "/opt/ros/jazzy/lib/python3.12/site-packages/rosidl_runtime_py/set_message.py", line 60, in set_message_fields_internal
    raise TypeError(
TypeError: Value '' is expected to be a dictionary but is a str
```

With the following yaml:

```yaml
header:
  stamp:
    sec: 1730513229
    nanosec: 6167372
  frame_id: ''
status:
- level: "\x02"
  name: 'geofence_node: Go GeoFences'
  message: No Geofences
  hardware_id: none
  values: []
- level: "\0"
  name: 'geofence_node: No Go GeoFences'
  message: Outside All
  hardware_id: none
  values: []
```

The `level` value is a string `\x02` but `set_message` is trying to convert it to the `field_type` `bytes`. This patch fixes this issue by encoding the string to bytes.
