### PR TITLE
Add py.typed to the package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
     ],
+    package_data={'': ['py.typed']},
     zip_safe=False,
     author='Dirk Thomas',
     author_email='dthomas@osrfoundation.org',


### PR DESCRIPTION
## Description

Adds a py.typed marker file to the package to indicate compliance with PEP 561,
enabling type checkers like mypy to recognize and validate the package's type hints.

Fixes #36 

### Is this user-facing behavior change?

Depending on type checkers config, maintainers of packages which depend
on this package, might have to fix type errors related to
usage of rosidl_runtime_py.

### Did you use Generative AI?

No

