### PR TITLE
Add support for rosidl::Buffer in rosidl Python path for rclpy

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -14,6 +14,7 @@
 
   <exec_depend>python3-numpy</exec_depend>
   <exec_depend>python3-yaml</exec_depend>
+  <exec_depend>rosidl_buffer_py</exec_depend>
   <exec_depend>rosidl_parser</exec_depend>
 
   <test_depend>ament_copyright</test_depend>

--- a/rosidl_runtime_py/convert.py
+++ b/rosidl_runtime_py/convert.py
@@ -14,7 +14,6 @@
 
 import array
 from collections import OrderedDict
-import itertools
 import sys
 from typing import Any
 
@@ -123,16 +122,8 @@ def message_to_csv(
                 r = __abbreviate_array_info(val, field_type)
             else:
                 values = val.to_bytes()
-                if truncate_length is not None:
-                    values = list(itertools.islice(values, truncate_length + 1))
-                    truncated = len(values) > truncate_length
-                    if truncated:
-                        values = values[:truncate_length]
-                else:
-                    values = list(values)
-                    truncated = False
-                r = ','.join(str(v) for v in values)
-                if truncated:
+                r = ','.join(str(v) for v in values[:truncate_length])
+                if truncate_length is not None and len(values) > truncate_length:
                     r += ',...'
         elif any(isinstance(val, t) for t in [list, tuple, array.array, numpy.ndarray]):
             if no_arr is True and field_type is not None:
@@ -233,15 +224,10 @@ def _convert_value(
         if no_arr and field_type is not None:
             value = __abbreviate_array_info(value, field_type)
         else:
-            values = value.to_bytes()
-            if truncate_length is not None:
-                values = list(itertools.islice(values, truncate_length + 1))
-                if len(values) > truncate_length:
-                    value = [int(v) for v in values[:truncate_length]] + ['...']
-                else:
-                    value = [int(v) for v in values]
-            else:
-                value = [int(v) for v in values]
+            bytestring = value.to_bytes()
+            value = [int(v) for v in bytestring[:truncate_length]]
+            if truncate_length is not None and len(bytestring) > truncate_length:
+                value += ['...']
     elif isinstance(value, (list, tuple, array.array, numpy.ndarray)):
         # Since arrays and ndarrays can't contain mixed types convert to list
         typename = tuple if isinstance(value, tuple) else list

--- a/rosidl_runtime_py/convert.py
+++ b/rosidl_runtime_py/convert.py
@@ -21,6 +21,8 @@ import numpy
 import rosidl_parser.definition
 import yaml
 
+from rosidl_buffer import Buffer as _RosidlBuffer
+
 
 __yaml_representer_registered = False
 
@@ -116,7 +118,19 @@ def message_to_csv(
     def to_string(val, field_type=None):
         nonlocal truncate_length, no_arr, no_str
         r = ''
-        if any(isinstance(val, t) for t in [list, tuple, array.array, numpy.ndarray]):
+        if isinstance(val, _RosidlBuffer):
+            if no_arr is True and field_type is not None:
+                r = __abbreviate_array_info(val, field_type)
+            else:
+                val = list(val.to_bytes())
+                for i, v in enumerate(val):
+                    if r:
+                        r += ','
+                    if truncate_length is not None and i >= truncate_length:
+                        r += '...'
+                        break
+                    r += to_string(v)
+        elif any(isinstance(val, t) for t in [list, tuple, array.array, numpy.ndarray]):
             if no_arr is True and field_type is not None:
                 r = __abbreviate_array_info(val, field_type)
             else:
@@ -211,6 +225,13 @@ def _convert_value(
             value = '<string length: <{0}>>'.format(len(value))
         elif truncate_length is not None and len(value) > truncate_length:
             value = value[:truncate_length] + '...'
+    elif isinstance(value, _RosidlBuffer):
+        if no_arr is True and field_type is not None:
+            value = __abbreviate_array_info(value, field_type)
+        else:
+            value = list(value.to_bytes())
+            if truncate_length is not None and len(value) > truncate_length:
+                value = value[:truncate_length] + ['...']
     elif isinstance(value, (list, tuple, array.array, numpy.ndarray)):
         # Since arrays and ndarrays can't contain mixed types convert to list
         typename = tuple if isinstance(value, tuple) else list

--- a/rosidl_runtime_py/convert.py
+++ b/rosidl_runtime_py/convert.py
@@ -14,14 +14,14 @@
 
 import array
 from collections import OrderedDict
+import itertools
 import sys
 from typing import Any
 
 import numpy
+from rosidl_buffer import Buffer as _RosidlBuffer
 import rosidl_parser.definition
 import yaml
-
-from rosidl_buffer import Buffer as _RosidlBuffer
 
 
 __yaml_representer_registered = False
@@ -119,17 +119,21 @@ def message_to_csv(
         nonlocal truncate_length, no_arr, no_str
         r = ''
         if isinstance(val, _RosidlBuffer):
-            if no_arr is True and field_type is not None:
+            if no_arr and field_type is not None:
                 r = __abbreviate_array_info(val, field_type)
             else:
-                val = list(val.to_bytes())
-                for i, v in enumerate(val):
-                    if r:
-                        r += ','
-                    if truncate_length is not None and i >= truncate_length:
-                        r += '...'
-                        break
-                    r += to_string(v)
+                values = val.to_bytes()
+                if truncate_length is not None:
+                    values = list(itertools.islice(values, truncate_length + 1))
+                    truncated = len(values) > truncate_length
+                    if truncated:
+                        values = values[:truncate_length]
+                else:
+                    values = list(values)
+                    truncated = False
+                r = ','.join(str(v) for v in values)
+                if truncated:
+                    r += ',...'
         elif any(isinstance(val, t) for t in [list, tuple, array.array, numpy.ndarray]):
             if no_arr is True and field_type is not None:
                 r = __abbreviate_array_info(val, field_type)
@@ -226,12 +230,18 @@ def _convert_value(
         elif truncate_length is not None and len(value) > truncate_length:
             value = value[:truncate_length] + '...'
     elif isinstance(value, _RosidlBuffer):
-        if no_arr is True and field_type is not None:
+        if no_arr and field_type is not None:
             value = __abbreviate_array_info(value, field_type)
         else:
-            value = list(value.to_bytes())
-            if truncate_length is not None and len(value) > truncate_length:
-                value = value[:truncate_length] + ['...']
+            values = value.to_bytes()
+            if truncate_length is not None:
+                values = list(itertools.islice(values, truncate_length + 1))
+                if len(values) > truncate_length:
+                    value = [int(v) for v in values[:truncate_length]] + ['...']
+                else:
+                    value = [int(v) for v in values]
+            else:
+                value = [int(v) for v in values]
     elif isinstance(value, (list, tuple, array.array, numpy.ndarray)):
         # Since arrays and ndarrays can't contain mixed types convert to list
         typename = tuple if isinstance(value, tuple) else list

--- a/rosidl_runtime_py/set_message.py
+++ b/rosidl_runtime_py/set_message.py
@@ -22,6 +22,8 @@ from typing import List
 
 import numpy
 
+from rosidl_buffer import Buffer as _RosidlBuffer
+
 from rosidl_parser.definition import AbstractNestedType
 from rosidl_parser.definition import NamespacedType
 from rosidl_runtime_py.convert import get_message_slot_types
@@ -69,6 +71,8 @@ def set_message_fields(
             qualified_class_name = '{}.{}'.format(field_type.__module__, field_type.__name__)
             if field_type is array.array:
                 value = field_type(field.typecode, field_value)
+            elif field_type is _RosidlBuffer:
+                value = array.array('B', field_value)
             elif field_type is numpy.ndarray:
                 value = numpy.array(field_value, dtype=field.dtype)
             elif type(field_value) is field_type:


### PR DESCRIPTION
## Description

This pull request updates the runtime Python utilities (`rosidl_runtime_py`) to handle `rosidl::Buffer` fields in message types.

This pull request consists of the following key changes:

- **`set_message.py`**: When setting message fields from a dict (e.g., via CLI tools), adds that if the current field holds a `rosidl_buffer.Buffer` type, constructs an `array.array('B', field_value)` to replace it.
- **`convert.py`**: In `message_to_yaml` and related helpers, detects `rosidl_buffer.Buffer` by type and uses `val.to_bytes()` to convert for abbreviation and display, so display of messages with Buffer fields works correctly.

### Is this user-facing behavior change?

This pull request does not change existing rclpy behavior. Existing code using `array.array` for `uint8[]` fields continues to work. The `rosidl_buffer.Buffer` type is only encountered when a subscriber receives data from a non-CPU buffer backend (and has opted in via `acceptable_buffer_backends`).

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

Yes. Claude (claude-4.6-opus) via Cursor was used to assist with creating an initial prototype version of the changes contained in this PR.

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->

This PR is part of the broader ROS 2 native buffer feature introduced in this [post](https://discourse.openrobotics.org/t/working-prototype-of-native-buffers-accelerated-memory-transport/52399). 